### PR TITLE
Update cheatsheet for 1.x and 2.x commands, split out charm-tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,22 @@
-# Juju Cheatsheet
+# Juju Cheatsheets
 
-Sometimes you don't have all day to figure stuff out, here's a TLDR of how to use Juju. Remember you can always `juju help` and then any of these subcommands to get the help for the command. 
+Juju changed the subcommands on the major release boundary. These documents are
+a summary of Juju commands for the major releases. For more detailed
+information please refer to the
+[official documentation](https://jujucharms.com/docs).
 
-## Installing the PPA and all the goodies:
+Remember you can always `juju help` and then any of these subcommands to get the
+help  for the specific command.
 
-- `sudo add-apt-repository ppa:juju/stable && sudo apt-get update && sudo apt-get install juju juju-local juju-quickstart charm-tools`
-- `juju quickstart -i` - prompts you for all your cloud credentials. 
-- `juju bootstrap -v` - bootstrap a node (always -v so you can see what's going on, drop the -v when you get comfortable with juju, but juju bootstrap since 1.17.0 shows what's going on -v is really verbose at this point)
-- `juju debug-log` - open this in another terminal or tab, so you can see what juju is doing while you type other commands)
+## Juju 1.x
 
-## Using Juju
+The [1.x Juju cheatsheet](juju_1.x.md) covers the original Juju subcommands.
 
-- `juju deploy servicename alias`- deploy a service, alias is optional if you want to name it something. If you use aliases you need to refer to the service via the alias from then on:
+## Juju 2.x
 
-                juju deploy mediawiki myawesomewiki
+The [2.x Juju cheatsheet](juju_2.x.md) covers the new Juju subcommands.
 
-- `juju add-unit servicename` - add a unit
-- `juju add-unit -n 10 servicename` - add 10 units.
-- `juju deploy servicename --to #` - deploy servicename to a specific machine #. Use 0 to deploy to the bootstrap node.
-- `juju status` - shows what's going on
-- `juju status servicename` - shows you what's going for a particular server
-- `juju ssh servicename/machine#` - ssh to a unit, get the # from juju status
-- `juju ssh machine#` - ssh to a machine number
-- `juju run "uname -a" --all` - Run a command (uname) on every instance. (1.17.2 and newer)
+## charmtools 2.x
 
-## bundles
-
-- `juju quickstart bundle:~abentley/wiki-bundle/1/wiki` - Get the bundle address from jujucharms.com
-
-## Relations
-
-- `juju add-relation $service1 $service2` - relate two services
-- `juju destroy-relation $service1 $service2` - unrelate 2 services
-
-## Deploying to Containers, VMs, and metal
-
-- `juju deploy servicename --to lxc:10` - Deploy service to a container on machine #10
-- `juju deploy servicename --to kvm:10` - Deploy service to a KVM on machine #10
-- `juju deploy servicename --to 10` - Deploy service to the raw bare metal on machine #10
-- `juju deploy servicename --constraints instance-type=m1.small` - Deploy to certain AWS types. 
-
-## Working with Units
-
-- `juju ssh servicename/#` - ssh to a specific machine # for a service.
-- `juju run --service servicename "uname -a"` - run a command on all machines of a service and return results to the console (useful!)
-- `juju scp file.sh servicename/0:/tmp` - copy file.sh to /tmp on node 0 of servicename.
-
-
-## Destroying Stuff
-
-- `juju destroy-environment $environment-name` - destroy an environment
-- `juju destroy-service $servicename` - destroy a service, DOES NOT REMOVE THE MACHINE, you need to follow up:
-- `juju destroy-machine` # - destroy machine # 
-
-## Writing Charms/Bundles
-
-- `charm create foo` - create a blank charm template
-- `charm add tests` - add tests to an existing charm
-- `charm test -e $environment` - executes all tests found in the charm tests directory in specified environment (amazon, hp, etc.).
-- `charm add readme` - add a readme template to an existing charm
-- `charm proof` - lint for charms
-- `bundle proof` - lint for bundles
-- `juju debug-hooks` - debug mode for charm writing, this will ssh you into the units and fire off a tmux session to debug (totally awesome, use this). 
-
-## Clean up
-
-- "I broke the local provider and need to start over" - http://askubuntu.com/questions/403618/how-do-i-clean-up-a-machine-after-using-the-local-provider
-- "There's a race somewhere and sometimes the unit doesn't come up" - `juju resolved $servicename --retry` 
-
-## Other
-
-- Listing of all the charms: https://jujucharms.com/fullscreen/search/?text=
-- `juju status -e $environmentname` - show me the status of another environment
-- `juju switch $environmentname` - switch to a different environment
-- `juju add-machine` - add a blank machine that you can mess with
-- `juju ensure-availability` - Ensures the state server is HA (+3 nodes) - you only really need this in production.
-
-## Useful LXC commands
-
-`sudo lxc-ls --fancy` - show all the containers on your machine
-
-## Plugins
-
-Install plugins:
-
-    git clone https://github.com/juju/plugins.git ~/.juju-plugins
-    echo 'PATH=$PATH:$HOME/.juju-plugins' >> ~/.bash_profile
-    source ~/.bash_profile
-    juju help plugins
-
-Plugin Cheats:
-
-- `juju pprint` - prettier status, a must for large deployments
-- `juju clean` - reset and clean all LXC containers and the Juju local provider
-- `juju git-deploy https://github.com/charms/haproxy` - Deploy charms directly from a git repo. 
-
+The [2.x charm-tools cheatsheet](charm-tools_2.x.md) covers the charm
+subcommands.

--- a/charm-tools_2.x.md
+++ b/charm-tools_2.x.md
@@ -1,0 +1,53 @@
+# charm-tools 2.x
+
+This is a summary of the 2.x charm-tools subcommands. For more detailed
+information refer to the [charm-tools documentation](https://jujucharms.com/docs/devel/tools-charm-tools).
+
+## Install charm-tools
+
+```sh
+sudo add-apt-repository -y ppa:juju/devel
+sudo add-apt-repository -y ppa:juju/stable
+sudo apt update -qq
+sudo apt install -y charm-tools
+```
+
+## charm-tools 2.x subcommands
+```
+add            - add icon, readme, or tests to a charm
+attach         - upload a file as a resource for a charm
+build          - build a charm from layers and interfaces
+create         - create a new charm
+grant          - grant charm or bundle permissions
+help           - show help on a command or other topic
+layers         - inspect the layers of a built charm
+list           - list charms for a given user name
+list-resources - display the resources for a charm in the charm store
+login          - login to the charm store
+logout         - logout from the charm store
+proof          - perform static analysis on a charm or bundle
+publish        - publish a charm or bundle
+pull           - download a charm or bundle from the charm store
+pull-source    - download the source code for a charm, layer, or interface
+push           - push a charm or bundle into the charm store
+revoke         - revoke charm or bundle permissions
+set            - set charm or bundle extra-info, home page or bugs URL
+show           - print information on a charm or bundle
+terms          - lists terms owned by the user
+test           - execute charm functional tests
+version        - display tooling version information
+whoami         - display jaas user id and group membership
+```
+
+## Using charm-tools
+
+##### `charm add`
+- `charm add tests` - Add things to an existing charm, such as icon, tests,
+readme (template).
+
+##### `charm attach`
+- `charm attach ~user/trusty/wordpress website-data ./foo.zip` - Upload a file
+as a resource for a charm.
+
+##### `charm build`
+- `charm build` - Build the layers and interfaces into a charm.

--- a/juju_1.x.md
+++ b/juju_1.x.md
@@ -1,0 +1,96 @@
+# Juju 1.x Cheatsheet
+
+Sometimes you don't have all day to figure stuff out, here's a TLDR of how to use Juju. Remember you can always `juju help` and then any of these subcommands to get the help for the command.
+
+## Installing the PPA and all the goodies:
+
+- `sudo add-apt-repository ppa:juju/stable && sudo apt-get update && sudo apt-get install juju juju-local juju-quickstart charm-tools`
+- `juju quickstart -i` - prompts you for all your cloud credentials.
+- `juju bootstrap -v` - bootstrap a node (always -v so you can see what's going on, drop the -v when you get comfortable with juju, but juju bootstrap since 1.17.0 shows what's going on -v is really verbose at this point)
+- `juju debug-log` - open this in another terminal or tab, so you can see what juju is doing while you type other commands)
+
+## Using Juju
+
+- `juju deploy servicename alias`- deploy a service, alias is optional if you want to name it something. If you use aliases you need to refer to the service via the alias from then on:
+
+                juju deploy mediawiki myawesomewiki
+
+- `juju add-unit servicename` - add a unit
+- `juju add-unit -n 10 servicename` - add 10 units.
+- `juju deploy servicename --to #` - deploy servicename to a specific machine #. Use 0 to deploy to the bootstrap node.
+- `juju status` - shows what's going on
+- `juju status servicename` - shows you what's going for a particular server
+- `juju ssh servicename/machine#` - ssh to a unit, get the # from juju status
+- `juju ssh machine#` - ssh to a machine number
+- `juju run "uname -a" --all` - Run a command (uname) on every instance. (1.17.2 and newer)
+
+## bundles
+
+- `juju quickstart bundle:~abentley/wiki-bundle/1/wiki` - Get the bundle address from jujucharms.com
+
+## Relations
+
+- `juju add-relation $service1 $service2` - relate two services
+- `juju destroy-relation $service1 $service2` - unrelate 2 services
+
+## Deploying to Containers, VMs, and metal
+
+- `juju deploy servicename --to lxc:10` - Deploy service to a container on machine #10
+- `juju deploy servicename --to kvm:10` - Deploy service to a KVM on machine #10
+- `juju deploy servicename --to 10` - Deploy service to the raw bare metal on machine #10
+- `juju deploy servicename --constraints instance-type=m1.small` - Deploy to certain AWS types.
+
+## Working with Units
+
+- `juju ssh servicename/#` - ssh to a specific machine # for a service.
+- `juju run --service servicename "uname -a"` - run a command on all machines of a service and return results to the console (useful!)
+- `juju scp file.sh servicename/0:/tmp` - copy file.sh to /tmp on node 0 of servicename.
+
+
+## Destroying Stuff
+
+- `juju destroy-environment $environment-name` - destroy an environment
+- `juju destroy-service $servicename` - destroy a service, DOES NOT REMOVE THE MACHINE, you need to follow up:
+- `juju destroy-machine` # - destroy machine #
+
+## Writing Charms/Bundles
+
+- `charm create foo` - create a blank charm template
+- `charm add tests` - add tests to an existing charm
+- `charm test -e $environment` - executes all tests found in the charm tests directory in specified environment (amazon, hp, etc.).
+- `charm add readme` - add a readme template to an existing charm
+- `charm proof` - lint for charms
+- `bundle proof` - lint for bundles
+- `juju debug-hooks` - debug mode for charm writing, this will ssh you into the units and fire off a tmux session to debug (totally awesome, use this).
+
+## Clean up
+
+- "I broke the local provider and need to start over" - http://askubuntu.com/questions/403618/how-do-i-clean-up-a-machine-after-using-the-local-provider
+- "There's a race somewhere and sometimes the unit doesn't come up" - `juju resolved $servicename --retry`
+
+## Other
+
+- Listing of all the charms: https://jujucharms.com/fullscreen/search/?text=
+- `juju status -e $environmentname` - show me the status of another environment
+- `juju switch $environmentname` - switch to a different environment
+- `juju add-machine` - add a blank machine that you can mess with
+- `juju ensure-availability` - Ensures the state server is HA (+3 nodes) - you only really need this in production.
+
+## Useful LXC commands
+
+`sudo lxc-ls --fancy` - show all the containers on your machine
+
+## Plugins
+
+Install plugins:
+
+    git clone https://github.com/juju/plugins.git ~/.juju-plugins
+    echo 'PATH=$PATH:$HOME/.juju-plugins' >> ~/.bash_profile
+    source ~/.bash_profile
+    juju help plugins
+
+Plugin Cheats:
+
+- `juju pprint` - prettier status, a must for large deployments
+- `juju clean` - reset and clean all LXC containers and the Juju local provider
+- `juju git-deploy https://github.com/charms/haproxy` - Deploy charms directly from a git repo.

--- a/juju_2.x.md
+++ b/juju_2.x.md
@@ -1,0 +1,200 @@
+# Juju 2.x Cheatsheet
+
+This is a summary of the Juju 2.x subcommands. For more detailed information
+refer to the official [Juju documentation](https://jujucharms.com/docs/devel/)
+
+All the juju subcommands have descriptive help, use `juju help $SUBCOMMAND` for
+more information about each subcommand.
+
+## Install Juju and charm-tools:
+
+Install the juju package and charm-tools:
+```sh
+sudo add-apt-repository -y ppa:juju/devel
+sudo add-apt-repository -y ppa:juju/stable
+sudo apt update -qq
+sudo apt install -y juju-2.0
+```
+
+## Juju 2.x subcommands:
+
+```
+actions                 alias for 'list-actions'
+add-cloud               Adds a user-defined cloud to Juju from among known cloud types.
+add-credential          Adds or replaces credentials for a cloud.
+add-machine             start a new, empty machine and optionally a container, or add a container to a machine
+add-machines            alias for 'add-machine'
+add-relation            add a relation between two services
+add-space               Add a new network space
+add-ssh-key             Adds a public SSH key to a model.
+add-ssh-keys            alias for 'add-ssh-key'
+add-storage             adds unit storage dynamically
+add-subnet              add an existing subnet to Juju
+add-unit                Adds one or more units to a deployed service.
+add-units               alias for 'add-unit'
+add-user                Adds a Juju user to a controller.
+agree                   agree to terms
+allocate                allocate budget to services
+attach                  upload a file as a resource for a service
+autoload-credentials    looks for cloud credentials and caches those for use by Juju when bootstrapping
+backups                 alias for 'list-backups'
+block                   list and enable model blocks
+bootstrap               Initializes a cloud environment.
+cached-images           alias for 'list-cached-images'
+change-user-password    changes the password for a user
+charm                   interact with charms
+collect-metrics         collect metrics on the given unit/service
+create-backup           create a backup
+create-budget           create a new budget
+create-model            create an model within the Juju Model Server
+create-storage-pool     create storage pool
+debug-hooks             launch a tmux session to debug a hook
+debug-log               Displays log messages for a model.
+debug-metrics           retrieve metrics collected by the given unit/service
+deploy                  deploy a new service or bundle
+destroy-controller      Destroys a controller.
+destroy-model           Terminate all machines and resources for a non-controller model.
+destroy-relation        alias for 'remove-relation'
+destroy-service         alias for 'remove-service'
+destroy-unit            alias for 'remove-unit'
+disable-user            Disables a Juju user.
+download-backup         get an archive file
+enable-ha               ensure that sufficient controllers exist to provide redundancy
+enable-user             Re-enables a previously disabled Juju user.
+expose                  Makes a service publicly available over the network.
+get-config              Displays configuration settings for a deployed service.
+get-configs             alias for 'get-config'
+get-constraints         Displays machine constraints for a service.
+get-model-config        Displays configuration settings for a model.
+get-model-constraints   Displays machine constraints for a model.
+grant                   Grants access to a Juju user for a model.
+gui                     open the Juju GUI in the default browser
+help                    show help on a command or other topic
+help-tool               show help on a juju charm tool
+import-ssh-key          Adds a public SSH key from a trusted identity source to a model.
+import-ssh-keys         alias for 'import-ssh-key'
+kill-controller         forcibly terminate all machines and other associated resources for a juju controller
+list-actions            list actions defined for a service
+list-agreements         list user's agreements
+list-all-blocks         list all blocks within the controller
+list-backups            get all metadata
+list-budgets            list budgets
+list-cached-images      shows cached os images
+list-clouds             Lists all clouds available to Juju.
+list-controllers        Lists all controllers.
+list-credentials        Lists credentials for a cloud.
+list-machine            alias for 'list-machines'
+list-machines           Lists machines in a model.
+list-models             Lists models a user can access on a controller.
+list-payloads           display status information about known payloads
+list-plans              list plans
+list-resources          show the resources for a service or unit
+list-shares             Shows all users with access to a model for the current controller.
+list-spaces             List known spaces, including associated subnets
+list-ssh-key            alias for 'list-ssh-keys'
+list-ssh-keys           Lists the currently known SSH keys for the current (or specified) model.
+list-storage            lists storage details
+list-storage-pools      list storage pools
+list-subnets            list subnets known to Juju
+list-users              Lists Juju users allowed to connect to a controller.
+login                   logs in to the controller
+logout                  logs out of the controller
+machine                 alias for 'list-machines'
+machines                alias for 'list-machines'
+publish                 publish charm to the store
+register                Registers a Juju user to a controller.
+remove-all-blocks       remove all blocks in the Juju controller
+remove-backup           delete a backup
+remove-cached-images    remove cached os images
+remove-credential       Removes credentials for a cloud.
+remove-machine          remove machines from the model
+remove-machines         alias for 'remove-machine'
+remove-relation         Removes an existing relation between two services.
+remove-service          Remove a service from the model.
+remove-ssh-key          Removes a public SSH key (or keys) from a model.
+remove-ssh-keys         alias for 'remove-ssh-key'
+remove-unit             remove service units from the model
+resolved                marks unit errors resolved
+resources               alias for 'list-resources'
+restore-backup          restore from a backup archive to a new controller
+retry-provisioning      retries provisioning for failed machines
+revoke                  Revokes access from a Juju user for a model.
+run                     run the commands on the remote targets specified
+run-action              queue an action for execution
+scp                     Transfers files to/from a Juju machine.
+set-budget              set the budget limit
+set-config              Sets configuration options for a service.
+set-configs             alias for 'set-config'
+set-constraints         Sets machine constraints for a service.
+set-default-credential  Sets the default credentials for a cloud.
+set-default-region      Sets the default region for a cloud.
+set-meter-status        sets the meter status on a service or unit
+set-model-config        Sets configuration keys on a model.
+set-model-constraints   Sets machine constraints on a model.
+set-plan                set the plan for a service
+show-action-output      show results of an action by ID
+show-action-status      show results of all actions filtered by optional ID prefix
+show-backup             get metadata
+show-budget             show budget usage
+show-cloud              Shows detailed information on a cloud.
+show-controller         Shows detailed information of a controller.
+show-controllers        alias for 'show-controller'
+show-machine            show a machines status
+show-machines           alias for 'show-machine'
+show-model              shows information about the current or specified model
+show-status             alias for 'status'
+show-storage            shows storage instance
+show-user               Show information about a user.
+spaces                  alias for 'list-spaces'
+ssh                     Initiates an SSH session or executes a command on a Juju machine.
+ssh-key                 alias for 'list-ssh-keys'
+ssh-keys                alias for 'list-ssh-keys'
+status                  Displays the current status of Juju, services, and units.
+status-history          output past statuses for the passed entity
+storage                 alias for 'list-storage'
+subnets                 alias for 'list-subnets'
+switch                  Selects or identifies the current controller and model.
+sync-tools              copy tools from the official tool store into a local model
+unblock                 unblock an operation that would alter a running model
+unexpose                Removes public availability over the network for a service.
+unset-model-config      Unsets model configuration.
+update-allocation       update an allocation
+update-clouds           Updates public cloud information available to Juju.
+upgrade-charm           upgrade a service's charm
+upgrade-gui             upgrade to a new Juju GUI version
+upgrade-juju            Upgrades Juju on all machines in a model.
+upload-backup           store a backup archive file remotely in juju
+version                 print the current version
+```
+
+## Using juju
+
+##### `juju add-cloud`
+- `juju add-cloud mycloud ~/mycloud.yaml` - Add a user defined cloud to Juju.
+
+##### `juju add-credential`
+
+##### `juju add-machine`
+
+##### `juju add-relation`
+
+##### `juju add-space`
+
+##### `juju add-unit`
+- `juju add-unit servicename` - add a unit
+- `juju add-unit -n 10 servicename` - add 10 units.
+
+##### `juju deploy`
+Juju version 2.x has the ability to deploy both charms and bundles.
+
+- `juju deploy servicename alias`- deploy a service, alias is optional if you
+ want to name it something. If you use aliases you need to refer to the service
+via the alias from then on:  
+```sh
+juju deploy mediawiki myawesomewiki
+```
+- `juju deploy path/to/charm --series trusty` - deploy a charm on your **local
+filesystem** you must also specify the series.
+- `juju deploy path/to/bundle.yaml` - deploy a bundle on your **local
+filesystem**.
+- `juju deploy servicename --to #` - deploy servicename to a specific machine #. Use 0 to deploy to the bootstrap node.


### PR DESCRIPTION
Addressing issue #4 changes the one page cheatsheet into 2 or 3. 

This is a work in progress, contributions welcome.
